### PR TITLE
option: delete access key pairs of inactive users

### DIFF
--- a/inactive_aws_users/main.py
+++ b/inactive_aws_users/main.py
@@ -1,46 +1,68 @@
-import slack
-import boto3
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
+
+import boto3
 from botocore.exceptions import ClientError
+
+import slack
+
 iam = boto3.client('iam')
 
 
 def lambda_handler(event, context):
     print(os.environ)
     today = datetime.now()
-    num_of_days = os.environ['NO_OF_DAYS']
-    webhook = os.environ['WEBHOOK_URL']
-    print(num_of_days)
+    num_of_days = os.environ.get('NO_OF_DAYS')
+    webhook = os.environ.get('WEBHOOK_URL')
+    delete_access_keys = os.environ.get('DELETE_ACCESS_KEYS')
+    if num_of_days:
+        print(num_of_days)
 
-    iam_users = list(filter(lambda user: 'PasswordLastUsed' in user,
-                            iam.list_users()['Users']))
+        iam_users = list(filter(lambda user: 'PasswordLastUsed' in user,
+                                iam.list_users()['Users']))
 
-    inactive_user_list = list(filter(lambda inactive_user: abs((
-        today.date() - inactive_user['PasswordLastUsed'].date()).days) > int(num_of_days), iam_users))
+        inactive_user_list = list(filter(lambda inactive_user: abs((
+            today.date() - inactive_user['PasswordLastUsed'].date()).days) > int(num_of_days), iam_users))
 
-    user_list = list(map(lambda u: u['UserName'], inactive_user_list))
-    slack_user_list = []
-    print(user_list)
-    for user in user_list:
-        try:
-            iam.delete_login_profile(UserName=user)
-            slack_user_list.append(user)
-        except ClientError as e:
-            print(user + " is already disabled")
+        user_list = list(map(lambda u: u['UserName'], inactive_user_list))
+        slack_user_list = []
+        print(user_list)
+        for user in user_list:
+            try:
+                iam.delete_login_profile(UserName=user)
+                slack_user_list.append(user)
+            except ClientError:
+                print(user + " is already disabled")
 
-    message = ""
-    for index, value in enumerate(slack_user_list):
-        message = message + str(index + 1) + "." + value + "\n"
+        if delete_access_keys:
+            for user in user.list:
+                try:
+                    for key in iam.list_access_keys(
+                            UserName=user).get('AccessKeyMetadata'):
+                        iam.delete_access_keys(
+                            UserName=user,
+                            AccessKeyId=key)
+                except ClientError as e:
+                    print(e)
 
-    if len(slack_user_list) > 0:
-        slack.message("green", "Disabled Inactive IAM Users",
-                      "Below user are not active for " + num_of_days + " days", message, webhook)
+        message = ""
+        for index, value in enumerate(slack_user_list):
+            message = message + str(index + 1) + "." + value + "\n"
 
+        if slack_user_list and webhook:
+            slack.message("green", "Disabled Inactive IAM Users",
+                          "Below user are not active for " + num_of_days + " days", message, webhook)
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "message": "Disabled Inactive IAM Users Execution successful",
+            }),
+        }
     return {
-        "statusCode": 200,
+        "statusCode": 500,
         "body": json.dumps({
-            "message": "Disabled Inactive IAM Users Execution successful",
-        }),
+            "message": "NumberOfDays unset"
+        })
     }

--- a/template.yaml
+++ b/template.yaml
@@ -28,6 +28,11 @@ Parameters:
     Default: ''
     Type: String
     Description: Provide your Slack Webhook URL?
+  DeleteAccessKeys:
+    Default: ''
+    Type: String
+    Description: Delete all access keys for inactive users too
+    AllowedValues: ['', 'true']
 
 Resources:
   DisableInactiveUsersFunction:
@@ -41,6 +46,7 @@ Resources:
         Variables:
           NO_OF_DAYS: !Ref NumberOfDays
           WEBHOOK_URL: !Ref WebhookUrl
+          DELETE_ACCESS_KEYS: !Ref DeleteAccessKeys
       Policies:
         - Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
## Changes

* ALEFix code fixer (https://github.com/dense-analysis/ale)
* add env var `DELETE_ACCESS_KEYS` which can be set to `true` to delete access key pairs of inactive users too (as `iam.delete_login_profile` only treats AWS console)
* check if `NO_OF_DAYS` is set, if not then fail with 500 and message